### PR TITLE
Optimize `NetworkPacket` struct size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ Cargo.lock
 .DS_Store
 .AppleDouble
 **/*.rs.bk
+flamegraph.html
+flamegraph.svg
+perf.data
+perf.data.old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11"
 udp-stream = { version = "0.0", default-features = false }
 
+# Benchmarks
+criterion = { version = "0.5" }
 
 #tun2.rs example
 tun2 = { version = "1.2", features = ["async"] }
@@ -44,7 +46,7 @@ tun = { version = "0.6.1", features = ["async"], default-features = false }
 wintun = { version = "0.4", default-features = false }
 
 [profile.release]
-opt-level = 'z'          # Optimize for size.
+opt-level = 's'          # Optimize for size (with loop vectorization enabled).
 lto = true               # Enable Link Time Optimization
 codegen-units = 1        # Reduce number of codegen units to increase optimizations.
 panic = "abort"          # Abort on panic
@@ -54,3 +56,14 @@ debug-assertions = false # Remove assertions from the binary.
 incremental = false      # Disable incremental compilation.
 overflow-checks = false  # Disable overflow checks.
 strip = true             # Automatically strip symbols from the binary.
+
+# Optimize for performance *and* compilation time
+[profile.bench]
+# Inherits from `release` profile
+opt-level = 3
+lto = false
+codegen-units = 16
+debug = true # Enable debug info for `perf(1)`
+incremental = true
+strip = "none"
+

--- a/examples/tun2.rs
+++ b/examples/tun2.rs
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         resp.update_checksum(req_payload);
                         let mut payload = resp.to_bytes().to_vec();
                         payload.extend_from_slice(req_payload);
-                        u.send(payload).await?;
+                        u.send(payload)?;
                     } else {
                         println!("ICMPv4");
                     }

--- a/examples/tun_wintun.rs
+++ b/examples/tun_wintun.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         resp.update_checksum(req_payload);
                         let mut payload = resp.to_bytes().to_vec();
                         payload.extend_from_slice(req_payload);
-                        u.send(payload).await?;
+                        u.send(payload)?;
                     } else {
                         println!("ICMPv4");
                     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -287,7 +287,7 @@ pub mod tests {
         let mut c = Criterion::default()
             .with_output_color(true)
             .without_plots()
-            .with_filter(&filter)
+            .with_filter(filter)
             .warm_up_time(Duration::from_secs_f32(0.5))
             .measurement_time(Duration::from_secs_f32(0.5))
             .profile_time(profile_time.map(|s| Duration::from_secs_f32(s.parse().unwrap())));

--- a/src/stream/udp.rs
+++ b/src/stream/udp.rs
@@ -1,10 +1,8 @@
 use crate::{
-    packet::{NetworkPacket, TransportHeader},
+    packet::{IpHeader, NetworkPacket, TransportHeader},
     IpStackError, TTL,
 };
-use etherparse::{
-    IpNumber, Ipv4Extensions, Ipv4Header, Ipv6Extensions, Ipv6FlowLabel, Ipv6Header, UdpHeader,
-};
+use etherparse::{IpNumber, Ipv4Header, Ipv6FlowLabel, Ipv6Header, UdpHeader};
 use std::{future::Future, net::SocketAddr, pin::Pin, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -71,7 +69,7 @@ impl IpStackUdpStream {
                 )
                 .map_err(IpStackError::from)?;
                 Ok(NetworkPacket {
-                    ip: etherparse::NetHeaders::Ipv4(ip_h, Ipv4Extensions::default()),
+                    ip: IpHeader::Ipv4(ip_h),
                     transport: TransportHeader::Udp(udp_header),
                     payload,
                 })
@@ -99,7 +97,7 @@ impl IpStackUdpStream {
                 )
                 .map_err(IpStackError::from)?;
                 Ok(NetworkPacket {
-                    ip: etherparse::NetHeaders::Ipv6(ip_h, Ipv6Extensions::default()),
+                    ip: IpHeader::Ipv6(ip_h),
                     transport: TransportHeader::Udp(udp_header),
                     payload,
                 })

--- a/src/stream/unknown.rs
+++ b/src/stream/unknown.rs
@@ -51,7 +51,7 @@ impl IpStackUnknownTransport {
     pub fn ip_protocol(&self) -> IpNumber {
         self.protocol
     }
-    pub async fn send(&self, mut payload: Vec<u8>) -> Result<(), Error> {
+    pub fn send(&self, mut payload: Vec<u8>) -> Result<(), Error> {
         loop {
             let packet = self.create_rev_packet(&mut payload)?;
             self.packet_sender


### PR DESCRIPTION
Hi.

I identified a performance bottleneck in `NetworkPacket` being 9376 bytes long! This amount was mainly contributed by `etherparse::NetHeaders` enum including `etherparse::Ipv{4,6}Extensions`, that are 1032 and 9236 bytes long respectively, while not being used anywhere in this project.

Since `NetworkPacket` is quiet often passed around in memory and it's so heavy that it caused `memmove` to kick in [ref](https://nnethercote.github.io/perf-book/type-sizes.html). This resulted in a significant amount of time being spent in `memmove` even for smaller payloads.

So excluding the ip extensions' data from the `NetworkPacket` resulted in 6000% performance gain for decoding small packets (64 bytes) and 200% gain for decoding large packets (65k bytes). The gain is decreasing because currently all the payload stored in `NetworkPacket` is still being copied to a `Vec`. 

<details>
<summary>Flamegraph for `decode_mtu_64` benchmark without the optimization</summary>

![decode_mtu_64](https://github.com/narrowlink/ipstack/assets/116499566/0a2c57fd-b473-4947-9528-f3dce69d28c9)
</details>

<details>
<summary>Flamegraph for `decode_mtu_64` benchmark with the optimization</summary>

![decode_mtu_64_optim](https://github.com/narrowlink/ipstack/assets/116499566/40e066d7-c05f-40a2-ad0f-150d8da4a1a4)

</details>

Also the way I wrapped `criterion` to allow it to benchmark private fields isn't really conventional, so feel free to discard associated commit if that doesn't fit this project.