### PR TITLE
feat: add mtu option for dynamic calculation of mss

### DIFF
--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     stream::tcb::{PacketType, Tcb, TcpState},
 };
-use etherparse::{IpNumber, Ipv4Header, Ipv6FlowLabel, TcpHeader, TcpOptionElement};
+use etherparse::{IpNumber, Ipv4Header, Ipv6FlowLabel, TcpHeader};
 use std::{
     future::Future,
     io::ErrorKind::{BrokenPipe, ConnectionRefused, InvalidInput, UnexpectedEof},
@@ -452,7 +452,7 @@ async fn tcp_main_logic_loop(
             &up_packet_sender,
             network_tuple,
             &tcb,
-            config.options.as_ref().as_deref().map(|o| {
+            config.options.as_ref().map(|o| {
                 (
                     o,
                     if network_tuple.src.is_ipv4() && network_tuple.dst.is_ipv4() {


### PR DESCRIPTION
  Due to the different header lengths of IPv4 and IPv6, the MSS (Maximum Segment Size) calculated using a fixed value should not be the same. An option should be added to pass the MTU (Maximum Transmission Unit) for dynamic calculation.

  Todo, since MSS is negotiated, the minimum value between the local and remote MSS should be used. However, the current API lacks a mechanism to retrieve the remote MSS, so functionality may need to be added to record the remote MSS during the SYN handshake.