### PR TITLE
Fix incorrect IP protocol in IPv6 unknown transport response packets

### DIFF
--- a/src/stream/unknown.rs
+++ b/src/stream/unknown.rs
@@ -190,7 +190,7 @@ impl IpStackUnknownTransport {
                     traffic_class: 0,
                     flow_label: Ipv6FlowLabel::ZERO,
                     payload_length: 0,
-                    next_header: IpNumber::UDP,
+                    next_header: self.protocol,
                     hop_limit: TTL,
                     source: dst.octets(),
                     destination: src.octets(),


### PR DESCRIPTION
When sending response packets for unknown transport protocols (e.g., ICMPv6, IGMP, ESP) over IPv6, the next_header field in the IPv6 header was hardcoded to IpNumber::UDP instead of using the actual protocol number (self.protocol).

This caused all unknown transport responses over IPv6 to incorrectly identify themselves as UDP packets, which would be silently dropped or rejected by the receiving network stack.

