### PR TITLE
Close a dropped TCP session without blocking on its task

### DIFF
--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -434,11 +434,22 @@ impl Drop for IpStackTcpStream {
         log::trace!("{nt} {state:?}: [drop] session dropping, ========================= ");
         if let Some(task_handle) = self.task_handle.take() {
             if !task_handle.is_finished() {
-                if let Some(notifier) = self.exit_notifier.take() {
-                    _ = tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(notifier.send(())));
+                // The farewell packet reaches the device through an unbounded channel, so it
+                // is sent here rather than left to the task.
+                {
+                    let mut tcb = self.tcb.lock().unwrap();
+                    if let Err(e) = send_fin_n_change_state_to_fin_wait1("[drop]", nt, &self.up_packet_sender, &mut tcb) {
+                        log::debug!("{nt} {state:?}: [drop] cannot send the farewell packet: {e}");
+                    }
                 }
-                // synchronously wait for the task to finish
-                _ = tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(task_handle));
+                if let Some(notifier) = self.exit_notifier.take() {
+                    // The channel holds ten slots and one signal ends the task, so the send
+                    // needs no runtime of its own.
+                    _ = notifier.try_send(());
+                }
+                // Dropping the task drops its `destroy_messenger`, which wakes the watcher
+                // that removes this session from the stack.
+                task_handle.abort();
             } else {
                 log::trace!("{nt} {state:?}: [drop] task already finished, no need to wait exiting");
             }


### PR DESCRIPTION
`IpStackTcpStream::drop` waits for the session's task through `block_in_place` and `block_on`. `block_in_place` works by handing the worker's core to the blocking pool, but the pool stops accepting work as soon as the runtime starts shutting down. A session dropped from that point on blocks its worker forever — the core is never handed off, so the task being waited for has no thread left to run on, and the runtime's shutdown is itself waiting for that worker. For a TUN proxy this happens on every exit with open connections: a handful of sessions usually gets away with it, a few hundred hangs the process for good. On a current-thread runtime the same line panics instead, which aborts the process from inside `Drop`.

This keeps what the waiting was for and drops the waiting. `send_fin_n_change_state_to_fin_wait1` is synchronous and writes to an unbounded channel, so the farewell packet is sent from the drop itself, under the same state guard. The exit signal becomes `try_send`, and the task is aborted rather than awaited — which drops its `destroy_messenger`, and since the watcher does `rx.await.ok()`, the session still leaves the stack.