### PR TITLE
Record an idle session's timeout at debug rather than warn

### DIFF
--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -306,12 +306,12 @@ impl AsyncRead for IpStackTcpStream {
                 let mut tcb = self.tcb.lock().unwrap();
                 let (seq, ack) = (tcb.get_seq().0, tcb.get_ack().0);
                 let l_info = format!("local {{ seq: {seq}, ack: {ack} }}");
-                log::warn!("{network_tuple} {state:?}: [poll_read] {l_info}, session timeout reached, closing forcefully...");
+                log::debug!("{network_tuple} {state:?}: [poll_read] {l_info}, session timeout reached, closing forcefully...");
                 let sender = &self.up_packet_sender;
                 write_packet_to_device(sender, network_tuple, &tcb, None, ACK | RST, None, None)?;
                 tcb.change_state(TcpState::Closed);
                 let state = tcb.get_state();
-                log::warn!("{network_tuple} {state:?}: [poll_read] {l_info}, session notified to close");
+                log::debug!("{network_tuple} {state:?}: [poll_read] {l_info}, session notified to close");
             }
             self.shutdown.lock().unwrap().ready();
 


### PR DESCRIPTION
A TCP session that goes quiet for longer than `TcpConfig::timeout` is closed with an RST. This is the configured behaviour working as intended, not a fault, but it is recorded at `warn` — twice per session, once before the state change and once after.

The surrounding lifecycle events in the same file already record at `debug`:

- `session begins` (tcp.rs:234)
- `[drop] session dropped` (tcp.rs:447)
- `[task_wait_to_close] session closed after {two_msl}` (tcp.rs:547)

Only the idle-timeout path departs from that. For a proxy holding many idle connections — HTTPS keep-alives routinely idle past 60 seconds — this fills the log with pairs of warnings for ordinary connection turnover, which is where an application looks for problems it can act on.

This moves the two lines in the timeout branch of `poll_read` to `debug`, matching the neighbouring events. No behaviour changes; the RST and the state transition are untouched.